### PR TITLE
Add back and forth prompt for a more chat like experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,16 @@ ai = AI('OpenAssistant/oasst-sft-1-pythia-12b')
 x = ai.generate("<|prompter|>What's the Earth total population<|endoftext|><|assistant|>", num_tokens_to_generate=100)
 print(x['token_str'])
 ```
+OR
 
+```bash
+python chat.py
+```
+chat.py accepts the following parameteres:
+
+- ``` -t 100 ``` Number of tokens to generate 
+- ```-p Tell me a joke``` for a single prompt interaction
+- ```-m pythia``` to load one of the available (bloom, pythia or gptj )
 
 We are working on adding support for `pip install cformers.`
 

--- a/chat.py
+++ b/chat.py
@@ -1,25 +1,35 @@
 import argparse
-parser = argparse.ArgumentParser()
-
+from interface import AutoInference as AI
 model_map = {'pythia': 'OpenAssistant/oasst-sft-1-pythia-12b', 'bloom': 'bigscience/bloom-7b1', 'gptj': 'EleutherAI/gpt-j-6B'}
 
+parser = argparse.ArgumentParser()
 parser.add_argument("-p", "--prompt", nargs="+",help="Enter a value for the prompt")
 parser.add_argument("-t", "--tokens",help="Number of tokens to generate",type=int, default=100)
 parser.add_argument("-m", "--model", help="Specify a Model", choices=model_map.keys(),default="pythia")
 args = parser.parse_args()
 
-from interface import AutoInference as AI
+def generate(prompt,arg=args):
+    print('Model is '+arg.model);
+    if arg.model == 'pythia':
+        x = ai.generate("<|prompter|>"+prompt+"<|endoftext|><|assistant|>", num_tokens_to_generate=arg.tokens)
+    elif arg.model == 'bloom':
+        x = ai.generate(""+prompt+"", num_tokens_to_generate=arg.tokens)
+    elif arg.model == 'gptj':
+        x = ai.generate(""+prompt+"", num_tokens_to_generate=arg.tokens)
+    else:
+        x = ai.generate("<|prompter|>"+prompt+"<|endoftext|><|assistant|>", num_tokens_to_generate=arg.tokens)
+    return x
+
 ai = AI(model_map[args.model])
 
 if not args.prompt:
     while True:
-        name = input("Please enter your prompt (type 'exit' to quit): ")
-        if name.lower() == 'exit':
+        my_prompt = input("Please enter your prompt (type 'exit' to quit): ")
+        if my_prompt.lower() == 'exit':
             break
-        x = ai.generate("<|prompter|>"+str(name)+"<|endoftext|><|assistant|>", num_tokens_to_generate=args.tokens)
+        x =generate(my_prompt,args)
         print(x['token_str'])
 else:
     my_prompt = ' '.join(args.prompt)
-    x = ai.generate("<|prompter|>"+my_prompt+"<|endoftext|><|assistant|>", num_tokens_to_generate=args.tokens)
+    x =generate( my_prompt,args)
     print(x['token_str'])
-

--- a/chat.py
+++ b/chat.py
@@ -1,0 +1,24 @@
+import argparse
+parser = argparse.ArgumentParser()
+
+model_map = {'pythia': 'OpenAssistant/oasst-sft-1-pythia-12b', 'bloom': 'BigScience/bloom-7b1', 'gptj': 'EleutherAI/gpt-j-6B'}
+
+parser.add_argument("-p", "--prompt", nargs="+",help="Enter a value for the prompt")
+parser.add_argument("-t", "--tokens",help="Number of tokens to generate",type=int, default=100)
+parser.add_argument("-m", "--model", help="Specify a Model", choices=model_map.keys(),default="pythia")
+args = parser.parse_args()
+
+from interface import AutoInference as AI
+ai = AI(model_map[args.model])
+
+if not args.prompt:
+    while True:
+        name = input("Please enter your prompt (type 'exit' to quit): ")
+        if name.lower() == 'exit':
+            break
+        x = ai.generate("<|prompter|>"+str(name)+"<|endoftext|><|assistant|>", num_tokens_to_generate=args.tokens)
+        print(x['token_str'])
+else:
+    my_prompt = ' '.join(args.prompt)
+    x = ai.generate("<|prompter|>"+my_prompt+"<|endoftext|><|assistant|>", num_tokens_to_generate=args.tokens)
+    print(x['token_str'])

--- a/chat.py
+++ b/chat.py
@@ -1,7 +1,7 @@
 import argparse
 parser = argparse.ArgumentParser()
 
-model_map = {'pythia': 'OpenAssistant/oasst-sft-1-pythia-12b', 'bloom': 'BigScience/bloom-7b1', 'gptj': 'EleutherAI/gpt-j-6B'}
+model_map = {'pythia': 'OpenAssistant/oasst-sft-1-pythia-12b', 'bloom': 'bigscience/bloom-7b1', 'gptj': 'EleutherAI/gpt-j-6B'}
 
 parser.add_argument("-p", "--prompt", nargs="+",help="Enter a value for the prompt")
 parser.add_argument("-t", "--tokens",help="Number of tokens to generate",type=int, default=100)
@@ -22,3 +22,4 @@ else:
     my_prompt = ' '.join(args.prompt)
     x = ai.generate("<|prompter|>"+my_prompt+"<|endoftext|><|assistant|>", num_tokens_to_generate=args.tokens)
     print(x['token_str'])
+

--- a/pythia.py
+++ b/pythia.py
@@ -1,0 +1,21 @@
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", "--prompt", nargs="+",help="Enter a value for the prompt")
+parser.add_argument("-t", "--tokens",help="Number of tokens to generate",type=int, default=100)
+args = parser.parse_args()
+
+from interface import AutoInference as AI
+ai = AI('OpenAssistant/oasst-sft-1-pythia-12b')
+
+if not args.prompt:
+    while True:
+        name = input("Please enter your prompt (type 'exit' to quit): ")
+        if name.lower() == 'exit':
+            break
+        x = ai.generate("<|prompter|>"+str(name)+"<|endoftext|><|assistant|>", num_tokens_to_generate=args.tokens)
+        print(x['token_str'])
+else:
+    my_prompt = ' '.join(args.prompt)
+    x = ai.generate("<|prompter|>"+my_prompt+"<|endoftext|><|assistant|>", num_tokens_to_generate=args.tokens)
+    print(x['token_str'])
+


### PR DESCRIPTION
A very simple way to interface with pythia without having to reload the model.

- Added the -t parameter that will allow you to specify how many tokens
- Added the -p parameter for you to send an input and get a response for that right away
- If no -p parameter is present, it'll ask the user to input the prompt until they type 'exit'

Usage:
`python pythia.py -t 200` for 200 tokens

`python pythia.py -t 200 -p tell me a joke` for getting a joke with 200 tokens