### PR TITLE
Update Makefile that causes error

### DIFF
--- a/cformers/cpp/Makefile
+++ b/cformers/cpp/Makefile
@@ -197,7 +197,6 @@ clean:
 
 main: main.cpp ggml.o utils.o
 	$(CXX) $(CXXFLAGS) main.cpp ggml.o utils.o -o main $(LDFLAGS)
-	./main -h
 
 quantizeBloom: quantize_bloom.cpp ggml.o utils.o
 	$(CXX) $(CXXFLAGS) quantize_bloom.cpp ggml.o utils.o -o quantize_bloom $(LDFLAGS)


### PR DESCRIPTION
I am trying to use this with docker and through that found this error.
#0 0.428 I llama.cpp build info:
#0 0.428 I UNAME_S:  Linux
#0 0.428 I UNAME_P:  x86_64
#0 0.428 I UNAME_M:  x86_64
#0 0.428 I CFLAGS:   -I.              -O3 -DNDEBUG -std=c11   -fPIC -pthread -mavx -mavx2 -mfma -mf16c -msse3
#0 0.428 I CXXFLAGS: -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -pthread
#0 0.428 I LDFLAGS:
#0 0.428 I CC:       cc (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
#0 0.428 I CXX:      g++ (Ubuntu 9.4.0-1ubuntu1~20.04.1) 9.4.0
#0 0.428
#0 0.428 cc  -I.              -O3 -DNDEBUG -std=c11   -fPIC -pthread -mavx -mavx2 -mfma -mf16c -msse3   -c ggml.c -o ggml.o
#0 4.087 g++ -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -pthread -c utils.cpp -o utils.o
#0 8.863 g++ -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -pthread main.cpp ggml.o utils.o -o main
#0 12.52 ./main -h
#0 12.52 argv[0] = ./main
#0 12.52 argv[1] = -h
#0 12.52 make: *** [Makefile:200: main] Error 1
 Removing it fixed the issue.