### PR TITLE
Add detailed error messaging for reading/writing of model files.

### DIFF
--- a/cformers/cpp/quantize_bloom.cpp
+++ b/cformers/cpp/quantize_bloom.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <map>
 #include <string>
+#include <system_error>
 #include <vector>
 #include <regex>
 
@@ -48,13 +49,15 @@ bool bloom_model_quantize(const std::string & fname_inp, const std::string & fna
 
     auto finp = std::ifstream(fname_inp, std::ios::binary);
     if (!finp) {
-        fprintf(stderr, "%s: failed to open '%s' for reading\n", __func__, fname_inp.c_str());
+        std::error_code ec(errno, std::generic_category());
+        fprintf(stderr, "%s: failed to open '%s' for reading: %s\n", __func__, fname_inp.c_str(), ec.message().c_str());
         return false;
     }
 
     auto fout = std::ofstream(fname_out, std::ios::binary);
     if (!fout) {
-        fprintf(stderr, "%s: failed to open '%s' for writing\n", __func__, fname_out.c_str());
+        std::error_code ec(errno, std::generic_category());
+        fprintf(stderr, "%s: failed to open '%s' for writing: %s\n", __func__, fname_out.c_str(), ec.message().c_str());
         return false;
     }
 

--- a/cformers/cpp/quantize_gpt2.cpp
+++ b/cformers/cpp/quantize_gpt2.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <map>
 #include <string>
+#include <system_error>
 #include <vector>
 #include <regex>
 
@@ -47,13 +48,15 @@ bool gpt2_model_quantize(const std::string & fname_inp, const std::string & fnam
 
     auto finp = std::ifstream(fname_inp, std::ios::binary);
     if (!finp) {
-        fprintf(stderr, "%s: failed to open '%s' for reading\n", __func__, fname_inp.c_str());
+        std::error_code ec(errno, std::generic_category());
+        fprintf(stderr, "%s: failed to open '%s' for reading: %s\n", __func__, fname_inp.c_str(), ec.message().c_str());
         return false;
     }
 
     auto fout = std::ofstream(fname_out, std::ios::binary);
     if (!fout) {
-        fprintf(stderr, "%s: failed to open '%s' for writing\n", __func__, fname_out.c_str());
+        std::error_code ec(errno, std::generic_category());
+        fprintf(stderr, "%s: failed to open '%s' for writing: %s\n", __func__, fname_out.c_str(), ec.message().c_str());
         return false;
     }
 

--- a/cformers/cpp/quantize_gptj.cpp
+++ b/cformers/cpp/quantize_gptj.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <map>
 #include <string>
+#include <system_error>
 #include <vector>
 #include <regex>
 
@@ -47,13 +48,15 @@ bool gptj_model_quantize(const std::string & fname_inp, const std::string & fnam
 
     auto finp = std::ifstream(fname_inp, std::ios::binary);
     if (!finp) {
-        fprintf(stderr, "%s: failed to open '%s' for reading\n", __func__, fname_inp.c_str());
+        std::error_code ec(errno, std::generic_category());
+        fprintf(stderr, "%s: failed to open '%s' for reading: %s\n", __func__, fname_inp.c_str(), ec.message().c_str());
         return false;
     }
 
     auto fout = std::ofstream(fname_out, std::ios::binary);
     if (!fout) {
-        fprintf(stderr, "%s: failed to open '%s' for writing\n", __func__, fname_out.c_str());
+	std::error_code ec(errno, std::generic_category());
+        fprintf(stderr, "%s: failed to open '%s' for writing: %s\n", __func__, fname_out.c_str(), ec.message().c_str());
         return false;
     }
 

--- a/cformers/cpp/quantize_gptneox.cpp
+++ b/cformers/cpp/quantize_gptneox.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <map>
 #include <string>
+#include <system_error>
 #include <vector>
 #include <regex>
 
@@ -48,13 +49,15 @@ bool gptneox_model_quantize(const std::string & fname_inp, const std::string & f
 
     auto finp = std::ifstream(fname_inp, std::ios::binary);
     if (!finp) {
-        fprintf(stderr, "%s: failed to open '%s' for reading\n", __func__, fname_inp.c_str());
+        std::error_code ec(errno, std::generic_category());
+        fprintf(stderr, "%s: failed to open '%s' for reading: %s\n", __func__, fname_inp.c_str(), ec.message().c_str());
         return false;
     }
 
     auto fout = std::ofstream(fname_out, std::ios::binary);
     if (!fout) {
-        fprintf(stderr, "%s: failed to open '%s' for writing\n", __func__, fname_out.c_str());
+        std::error_code ec(errno, std::generic_category());
+        fprintf(stderr, "%s: failed to open '%s' for writing: %s\n", __func__, fname_out.c_str(), ec.message().c_str());
         return false;
     }
 


### PR DESCRIPTION
I was trying to quantize a gptj model and the code failed to quantize it.
I was wondering what the problem was since the error message wasn't very detailed and the help message of the converters weren't very detailed either.

I followed some steps mentioned here: https://github.com/NolanoOrg/cformers/issues/32#issuecomment-1486199991
Turns out the convert code needs an output directory but the quantize code needs the absolute path to the file name and not an output directory.

So I added some detailed error messaging to clarify that. Now it prints the error code:
```
~/code/oss/cformers/cformers/cpp > ./quantize_gptj ~/.cformers/models/gptj/modelOne/modelOne-f32.bin . 2
gptj_model_quantize: loading model from '/Users/aghatage/.cformers/models/gptj/modelOne/modelOne-f32.bin'
gptj_model_quantize: failed to open '/Users/aghatage/.cformers/models/gptj/modelOne/modelOne-f32.bin' for reading: No such file or directory
main: failed to quantize model from '/Users/aghatage/.cformers/models/gptj/modelOne/modelOne-f32.bin'
```