### PR TITLE
Fix non-parallel residual for GPT-NeoX

### DIFF
--- a/cformers/cpp/main.cpp
+++ b/cformers/cpp/main.cpp
@@ -2324,13 +2324,13 @@ bool gptneox_eval(
         struct ggml_tensor * inpFF;
 
         if (hparams.use_parallel_residual == 0) {
-            printf("use_parallel_residual == 0\n");
+            //printf("use_parallel_residual == 0\n");
             // This takes the self-attention residual output as input to Feedforward
-            inpFF = ggml_add(ctx0, cur, inpL);
+            cur = ggml_add(ctx0, cur, inpL);
 
             // post attention layer norm
             {
-                inpFF = ggml_norm(ctx0, inpFF);
+                inpFF = ggml_norm(ctx0, cur);
 
                 // inpFF = input_layernorm_weight*inpFF + input_layernorm_bias
                 inpFF = ggml_add(ctx0,
@@ -2354,8 +2354,8 @@ bool gptneox_eval(
                 inpFF = ggml_add(ctx0, ggml_repeat(ctx0, model.layers[il].c_mlp_proj_b, inpFF), inpFF);
             }
 
-            // inpL = inpFF + inpL
-            inpL = ggml_add(ctx0, inpFF, inpL);
+            // inpL = inpFF + cur
+            inpL = ggml_add(ctx0, inpFF, cur);
 
         } else if (hparams.use_parallel_residual == 1) {
             // printf("use_parallel_residual == 1\n");


### PR DESCRIPTION
This fixes generation with [RedPajama](https://huggingface.co/togethercomputer/RedPajama-INCITE-Instruct-3B-v1/tree/main) model that uses non-parallel case.

Before (after commenting out `printf("use_parallel_residual == 0\n");` so that the output is handled correctly by python script):
```
Please enter your prompt (type 'exit' to quit): Hello
....
Hello"}).(?erfatilyettiqeleventio 1.ICAokley Sunoosersyoulippidaato0Pantonicbelelwilliottervegomeraczeasinschanzesimshdeu00fosterKristjanusmsie "their 20IDCAubojyaeras and othersD3 New Year Bailistvio1029anreds, as they’lyudnidaaerridthr Gogigafy
```

After:
```
Please enter your prompt (type 'exit' to quit): def hello_world:
...
<|BEGIN> def hello_world:
    @hello = "Hello World!"

Q:

How do I create a custom type in C++? (Not the STL one)?

My goal is to make my own class that inherits from std::list. The problem i have with this approach though, if someone asks me for example what its position number should be when we move it by 1 or 2 then I can't say 'this will work as an answer' because there are no examples of how
---------------------

def hello_world:
    @hello = "Hello World!"

Q:

How do I create a custom type in C++? (Not the STL one)?

My goal is to make my own class that inherits from std::list. The problem i have with this approach though, if someone asks me for example what its position number should be when we move it by 1 or 2 then I can't say 'this will work as an answer' because there are no examples of how

```


See [Transofmers](https://github.com/huggingface/transformers/blob/main/src/transformers/models/gpt_neox/modeling_gpt_neox.py#L348-L353) source code for reference.